### PR TITLE
Add support for Ruby 2.7 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       RUBY_VERSION: ${{ matrix.ruby }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", 3.1", "3.2", "3.3", head]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", head]
     env:
       RAILS_ENV: test
       RUBY_VERSION: ${{ matrix.ruby }}

--- a/lib/oyencov/test_reporting.rb
+++ b/lib/oyencov/test_reporting.rb
@@ -13,7 +13,7 @@ module OyenCov
       test_report_path = OyenCov.config.test_resultset_path
 
       report_content = {
-        controller_action_hits:
+        controller_action_hits: controller_action_hits
       }
 
       report_content_json = JSON.generate(report_content)

--- a/oyencov.gemspec
+++ b/oyencov.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     "bug_tracker_uri" => "https://github.com/oyencov/sdk-ruby/issues"
   }
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 2.7.0"
 
   s.add_development_dependency "rake", "~> 13.1"
   s.add_development_dependency "minitest", "~> 5.20"


### PR DESCRIPTION
Mainly to support one of the first users with older codebase. 

Did some basic testing with their project, seems to work, but kena put into production to see if there are further issues.

Will build 0.0.6 out of this.


- **Update gemspec and fix gh workflow yaml syntax**
- **Remove syntax sugar not supported in ruby < 3.1 -- Hash literal, kwarg short form**
- **Bump gh-actions checkout to suppress nodejs version warning**
